### PR TITLE
conf/machine/*.conf: used ?= in preferred kernel provider assignment.

### DIFF
--- a/conf/machine/duovero.conf
+++ b/conf/machine/duovero.conf
@@ -12,7 +12,7 @@ require conf/machine/include/soc-family.inc
 require conf/machine/include/tune-cortexa8.inc
 
 # Specify kernel recipe
-PREFERRED_PROVIDER_virtual/kernel = "linux-gumstix"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-gumstix"
 # Increase this everytime you change something in the kernel
 MACHINE_KERNEL_PR = "r0"
 KERNEL_IMAGETYPE = "uImage"

--- a/conf/machine/overo.conf
+++ b/conf/machine/overo.conf
@@ -11,7 +11,7 @@ require conf/machine/include/soc-family.inc
 require conf/machine/include/tune-cortexa8.inc
 
 # Specify kernel recipe
-PREFERRED_PROVIDER_virtual/kernel = "linux-gumstix"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-gumstix"
 # Increase this everytime you change something in the kernel
 MACHINE_KERNEL_PR = "r1"
 KERNEL_IMAGETYPE = "uImage"

--- a/conf/machine/pepper.conf
+++ b/conf/machine/pepper.conf
@@ -11,7 +11,7 @@ require conf/machine/include/soc-family.inc
 require conf/machine/include/tune-cortexa8.inc
 
 # Specify kernel recipe
-PREFERRED_PROVIDER_virtual/kernel = "linux-gumstix"
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-gumstix"
 # Increase this everytime you change something in the kernel
 MACHINE_KERNEL_PR = "r0"
 KERNEL_IMAGETYPE = "uImage"


### PR DESCRIPTION
Using a default value assignment (?=) makes it easier to change the virtual/kernel recipe. This is useful when trying out the CONFIG_PREEMPT_RT patch, for example.
