### PR TITLE
overo.conf: support meta-ti ti-dsplink builds

### DIFF
--- a/conf/machine/overo.conf
+++ b/conf/machine/overo.conf
@@ -54,3 +54,6 @@ MACHINE_EXTRA_RDEPENDS += "linux-firmware-sd8686"
 # Ship all kernel modules by default
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules"
 MACHINE_FEATURES = "alsa bluetooth ext2 screen touchscreen usbgadget usbhost vfat wifi"
+
+# TI dsplink
+TOOLCHAIN_PATH ?= "${STAGING_DIR_NATIVE}${prefix_native}/bin/${TUNE_PKGARCH}${HOST_VENDOR}-${HOST_OS}"


### PR DESCRIPTION
Without this commit builds of ti-dsplink from meta-ti fail due to inability to find the correct compiler.
