### PR TITLE
u-boot patches

### DIFF
--- a/recipes-bsp/u-boot/u-boot-2013.07/0001-omap-overo-update-support-for-Micron-1GB-POP.patch
+++ b/recipes-bsp/u-boot/u-boot-2013.07/0001-omap-overo-update-support-for-Micron-1GB-POP.patch
@@ -1,0 +1,44 @@
+From de8d979207534a17da11530df97d80e4f9b3a7ea Mon Sep 17 00:00:00 2001
+From: Steve Sakoman <steve@sakoman.com>
+Date: Sun, 21 Oct 2012 21:33:28 -0700
+Subject: [PATCH 1/2] omap: overo: update support for Micron 1GB POP
+
+Upstream-Status: Pending
+Signed-off-by: Ash Charles <ashcharles@gmail.com>
+---
+ board/overo/overo.c |    6 ++++++
+ board/overo/overo.h |    1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/board/overo/overo.c b/board/overo/overo.c
+index c10c44c..8df077d 100644
+--- a/board/overo/overo.c
++++ b/board/overo/overo.c
+@@ -169,6 +169,12 @@ void get_board_mem_timings(struct board_sdrc_timings *timings)
+ 		timings->ctrlb = HYNIX_V_ACTIMB_165;
+ 		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_165MHz;
+ 		break;
++	case REVISION_3: /* Micron 512MB/1024MB, 1/2 banks of 512MB */
++		timings->mcfg = MCFG(512 << 20, 15);
++		timings->ctrla = MICRON_V_ACTIMA_200;
++		timings->ctrlb = MICRON_V_ACTIMB_200;
++		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_200MHz;
++		break;
+ 	default:
+ 		timings->mcfg = MICRON_V_MCFG_165(128 << 20);
+ 		timings->ctrla = MICRON_V_ACTIMA_165;
+diff --git a/board/overo/overo.h b/board/overo/overo.h
+index b41b628..b984a54 100644
+--- a/board/overo/overo.h
++++ b/board/overo/overo.h
+@@ -37,6 +37,7 @@ const omap3_sysinfo sysinfo = {
+ #define REVISION_0	0x0
+ #define REVISION_1	0x1
+ #define REVISION_2	0x2
++#define REVISION_3	0x3
+ 
+ /*
+  * IEN  - Input Enable
+-- 
+1.7.9.5
+

--- a/recipes-bsp/u-boot/u-boot-2013.07/0002-omap-overo-Use-200MHz-SDRC-timings-for-revision-1-2-.patch
+++ b/recipes-bsp/u-boot/u-boot-2013.07/0002-omap-overo-Use-200MHz-SDRC-timings-for-revision-1-2-.patch
@@ -1,0 +1,47 @@
+From c9aaf36152bb4e22560a79fe1ca91798f48fb43b Mon Sep 17 00:00:00 2001
+From: Ash Charles <ashcharles@gmail.com>
+Date: Wed, 17 Jul 2013 15:17:19 -0700
+Subject: [PATCH 2/2] omap: overo: Use 200MHz SDRC timings for revision 1, 2 &
+ 3 boards
+
+Gumstix uses 200Mhz RAM on revision 1, 2 & 3 COMs, so use 200MHz
+timings rather than 165MHz.  Based on 6cf8bf44b1f8550e12f7f2a16e01890e5de8443d
+
+Upstream-Status: Pending
+Signed-off-by: Ash Charles <ashcharles@gmail.com>
+---
+ board/overo/overo.c |   16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/board/overo/overo.c b/board/overo/overo.c
+index 8df077d..c70fcc3 100644
+--- a/board/overo/overo.c
++++ b/board/overo/overo.c
+@@ -158,16 +158,16 @@ void get_board_mem_timings(struct board_sdrc_timings *timings)
+ 		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_165MHz;
+ 		break;
+ 	case REVISION_1: /* Micron 256MB/512MB, 1/2 banks of 256MB */
+-		timings->mcfg = MICRON_V_MCFG_165(256 << 20);
+-		timings->ctrla = MICRON_V_ACTIMA_165;
+-		timings->ctrlb = MICRON_V_ACTIMB_165;
+-		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_165MHz;
++		timings->mcfg = MICRON_V_MCFG_200(256 << 20);
++		timings->ctrla = MICRON_V_ACTIMA_200;
++		timings->ctrlb = MICRON_V_ACTIMB_200;
++		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_200MHz;
+ 		break;
+ 	case REVISION_2: /* Hynix 256MB/512MB, 1/2 banks of 256MB */
+-		timings->mcfg = HYNIX_V_MCFG_165(256 << 20);
+-		timings->ctrla = HYNIX_V_ACTIMA_165;
+-		timings->ctrlb = HYNIX_V_ACTIMB_165;
+-		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_165MHz;
++		timings->mcfg = HYNIX_V_MCFG_200(256 << 20);
++		timings->ctrla = HYNIX_V_ACTIMA_200;
++		timings->ctrlb = HYNIX_V_ACTIMB_200;
++		timings->rfr_ctrl = SDP_3430_SDRC_RFR_CTRL_200MHz;
+ 		break;
+ 	case REVISION_3: /* Micron 512MB/1024MB, 1/2 banks of 512MB */
+ 		timings->mcfg = MCFG(512 << 20, 15);
+-- 
+1.7.9.5
+

--- a/recipes-bsp/u-boot/u-boot-2013.07/0003-omap-overo-allow-the-use-of-a-plain-text-env-file-in.patch
+++ b/recipes-bsp/u-boot/u-boot-2013.07/0003-omap-overo-allow-the-use-of-a-plain-text-env-file-in.patch
@@ -1,0 +1,67 @@
+From 65639fb64dab653f02464dac73a99a511fc596d3 Mon Sep 17 00:00:00 2001
+From: "Peter A. Bigot" <pab@pabigot.com>
+Date: Sun, 4 Aug 2013 12:21:59 -0500
+Subject: [PATCH 3/3] omap: overo: allow the use of a plain text env file
+ instead boot scripts
+
+Adapted from d70f5480 described below.
+
+    commit d70f54808dfa83b574e1239c3eccbcf3317343e1
+    Author: Javier Martinez Canillas <javier@dowhile0.org>
+    Date:   Mon Jan 7 03:51:20 2013 +0000
+
+    omap4: allow the use of a plain text env file instead boot scripts
+
+    For production systems it is better to use script images since
+    they are protected by checksums and carry valuable information like
+    name and timestamp. Also, you can't validate the content passed to
+    env import.
+
+    But for development, it is easier to use the env import command and
+    plain text files instead of script-images.
+
+    Since both OMAP4 supported boards (Panda and TI SDP4430) are used
+    primarily for development, this patch allows U-Boot to load env var
+    from a text file in case that an boot.scr script-image is not present.
+
+    The variable uenvcmd (if existent) will be executed (using run) after
+    uEnv.txt was loaded. If uenvcmd doesn't exist the default boot sequence
+    will be started.
+
+Upstream-Status: Pending
+Signed-off-by: Peter A. Bigot <pab@pabigot.com>
+---
+ include/configs/omap3_overo.h |   10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/include/configs/omap3_overo.h b/include/configs/omap3_overo.h
+index fd31c73..baa7564 100644
+--- a/include/configs/omap3_overo.h
++++ b/include/configs/omap3_overo.h
+@@ -178,6 +178,9 @@
+ 	"loadbootscript=fatload mmc ${mmcdev} ${loadaddr} boot.scr\0" \
+ 	"bootscript=echo Running bootscript from mmc ...; " \
+ 		"source ${loadaddr}\0" \
++	"loadbootenv=fatload mmc ${mmcdev} ${loadaddr} uEnv.txt\0" \
++	"importbootenv=echo Importing environment from mmc${mmcdev} ...; " \
++		"env import -t ${loadaddr} ${filesize}\0" \
+ 	"loaduimage=fatload mmc ${mmcdev} ${loadaddr} uImage\0" \
+ 	"mmcboot=echo Booting from mmc ...; " \
+ 		"run mmcargs; " \
+@@ -192,6 +195,13 @@
+ 		"if run loadbootscript; then " \
+ 			"run bootscript; " \
+ 		"else " \
++			"if run loadbootenv; then " \
++				"run importbootenv; " \
++				"if test -n ${uenvcmd}; then " \
++					"echo Running uenvcmd ...;" \
++					"run uenvcmd;" \
++				"fi;" \
++			"fi;" \
+ 			"if run loaduimage; then " \
+ 				"run mmcboot; " \
+ 			"else run nandboot; " \
+-- 
+1.7.9.5
+

--- a/recipes-bsp/u-boot/u-boot_2013.07.bb
+++ b/recipes-bsp/u-boot/u-boot_2013.07.bb
@@ -1,12 +1,14 @@
 require u-boot.inc
 
 PV = "2013.07"
-PR = "r0"
+PR = "r2"
 
 COMPATIBLE_MACHINE = "overo"
 
-SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/gumstix/u-boot.git;branch=v2013.07;protocol=git \
-           file://fw_env.config \
+SRCREV = "62c175fbb8a0f9a926c88294ea9f7e88eb898f6c"
+SRC_URI = "git://git.denx.de/u-boot.git;branch=master;protocol=git \
+          file://0001-omap-overo-update-support-for-Micron-1GB-POP.patch \
+          file://0002-omap-overo-Use-200MHz-SDRC-timings-for-revision-1-2-.patch \
+          file://fw_env.config \
           "
 SPL_BINARY = "MLO"

--- a/recipes-bsp/u-boot/u-boot_2013.07.bb
+++ b/recipes-bsp/u-boot/u-boot_2013.07.bb
@@ -1,7 +1,7 @@
 require u-boot.inc
 
 PV = "2013.07"
-PR = "r2"
+PR = "r3"
 
 COMPATIBLE_MACHINE = "overo"
 
@@ -9,6 +9,7 @@ SRCREV = "62c175fbb8a0f9a926c88294ea9f7e88eb898f6c"
 SRC_URI = "git://git.denx.de/u-boot.git;branch=master;protocol=git \
           file://0001-omap-overo-update-support-for-Micron-1GB-POP.patch \
           file://0002-omap-overo-Use-200MHz-SDRC-timings-for-revision-1-2-.patch \
+          file://0003-omap-overo-allow-the-use-of-a-plain-text-env-file-in.patch \
           file://fw_env.config \
           "
 SPL_BINARY = "MLO"


### PR DESCRIPTION
Two changes:
- Base u-boot on the official denx repository and add gumstix patches.  I believe the current approach of having a recipe that references a branch on a gumstix fork is fragile: pushes to that branch will result in content changes to the u-boot package without any reflection of that in version number.
- Back-port an upstream feature available on most omap boards that reads environment settings from an mmc file during the boot process.  This allows image-specific environment settings to be coupled with the image, while not contaminating a clean NAND environment as desired when using the same physical board for a variety of purposes.

I recommend pushing the patches that are accepted (which should be at least the first two) upstream so they can be dropped from future gumstix BSP releases.
