### PR TITLE
bluez4: enable hard-wired bluetooth adapter on ttyO1

### DIFF
--- a/recipes-connectivity/bluez/bluez4_4.101.bbappend
+++ b/recipes-connectivity/bluez/bluez4_4.101.bbappend
@@ -1,0 +1,18 @@
+# Add required hciattach for optional on-board Wi2Wi bluetooth adapter
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+PRINC := "${@int(PRINC) + 1}"
+
+SRC_URI += " \
+  file://bluetooth-ttyO1.service \
+  file://bluetooth-ttyO1.conf \
+"
+
+SYSTEMD_SERVICE_${PN} += "bluetooth-ttyO1.service"
+
+do_install_append() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/bluetooth-ttyO1.service ${D}${systemd_unitdir}/system
+    install -d ${D}${systemd_unitdir}/system/bluetooth.service.d
+    install -m 0644 ${WORKDIR}/bluetooth-ttyO1.conf ${D}${systemd_unitdir}/system/bluetooth.service.d
+}
+

--- a/recipes-connectivity/bluez/files/bluetooth-ttyO1.conf
+++ b/recipes-connectivity/bluez/files/bluetooth-ttyO1.conf
@@ -1,0 +1,4 @@
+[Unit]
+# Retroactively add a weak dependency so bluetooth-ttyO1.service is started
+# when bluetooth.service is started.
+Wants=bluetooth-ttyO1.service

--- a/recipes-connectivity/bluez/files/bluetooth-ttyO1.service
+++ b/recipes-connectivity/bluez/files/bluetooth-ttyO1.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Attach Wi2Wi CSR Bluetooth Adapter hardwired to ttyO1
+Requires=bluetooth.service
+After=bluetooth.service
+Wants=bluetooth.target
+Before=bluetooth.target
+
+[Service]
+ExecStart=/usr/sbin/hciattach -n ttyO1 csr
+
+[Install]                                                                       
+WantedBy=bluetooth.target


### PR DESCRIPTION
This retains upstream behavior of bluetooth being disabled, but adds the hooks necessary so that "systemctl enable bluetooth.service" also ensures the bluetooth-ttyO1.service is enabled automatically.  Seems to work nicely for me.

Gumstix COMs that have the Wi2Wi module provide bluetooth support through an
HCI/UART interface directly connected to the CPU's ttyO1 serial port.  This
additional service enables that interface when bluetooth is enabled.

Signed-off-by: Peter A. Bigot pab@pabigot.com
