### PR TITLE
linux-gumstix 3.5: backport patch for mt9v032 module problem 

### DIFF
--- a/recipes-kernel/linux/linux-gumstix-3.5/0033-v4l-Reset-subdev-v4l2_dev-field-to-NULL-if-registrat.patch
+++ b/recipes-kernel/linux/linux-gumstix-3.5/0033-v4l-Reset-subdev-v4l2_dev-field-to-NULL-if-registrat.patch
@@ -1,0 +1,86 @@
+Backport patch required to allow mt9v032 module to be unloaded if
+the camera is not installed.
+
+Upstream-Status: Backport [317efce991620adc589b3005b9baed433dcb2a56]
+Signed-off-by: Peter A. Bigot <pab@pabigot.com>
+
+From: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+Date: Sat, 24 Nov 2012 21:35:48 -0300
+Subject: [PATCH 33/33] v4l: Reset subdev v4l2_dev field to NULL if
+ registration fails
+
+When subdev registration fails the subdev v4l2_dev field is left to a
+non-NULL value. Later calls to v4l2_device_unregister_subdev() will
+consider the subdev as registered and will module_put() the subdev
+module without any matching module_get().
+Fix this by setting the subdev v4l2_dev field to NULL in
+v4l2_device_register_subdev() when the function fails.
+
+Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+Cc: stable@vger.kernel.org
+Acked-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@redhat.com>
+---
+ drivers/media/video/v4l2-device.c |   30 ++++++++++++++----------------
+ 1 file changed, 14 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/media/video/v4l2-device.c b/drivers/media/video/v4l2-device.c
+index 1f203b8..683ae99 100644
+--- a/drivers/media/video/v4l2-device.c
++++ b/drivers/media/video/v4l2-device.c
+@@ -159,31 +159,21 @@ int v4l2_device_register_subdev(struct v4l2_device *v4l2_dev,
+ 	sd->v4l2_dev = v4l2_dev;
+ 	if (sd->internal_ops && sd->internal_ops->registered) {
+ 		err = sd->internal_ops->registered(sd);
+-		if (err) {
+-			module_put(sd->owner);
+-			return err;
+-		}
++		if (err)
++			goto error_module;
+ 	}
+ 
+ 	/* This just returns 0 if either of the two args is NULL */
+ 	err = v4l2_ctrl_add_handler(v4l2_dev->ctrl_handler, sd->ctrl_handler);
+-	if (err) {
+-		if (sd->internal_ops && sd->internal_ops->unregistered)
+-			sd->internal_ops->unregistered(sd);
+-		module_put(sd->owner);
+-		return err;
+-	}
++	if (err)
++		goto error_unregister;
+ 
+ #if defined(CONFIG_MEDIA_CONTROLLER)
+ 	/* Register the entity. */
+ 	if (v4l2_dev->mdev) {
+ 		err = media_device_register_entity(v4l2_dev->mdev, entity);
+-		if (err < 0) {
+-			if (sd->internal_ops && sd->internal_ops->unregistered)
+-				sd->internal_ops->unregistered(sd);
+-			module_put(sd->owner);
+-			return err;
+-		}
++		if (err < 0)
++			goto error_unregister;
+ 	}
+ #endif
+ 
+@@ -192,6 +182,14 @@ int v4l2_device_register_subdev(struct v4l2_device *v4l2_dev,
+ 	spin_unlock(&v4l2_dev->lock);
+ 
+ 	return 0;
++
++error_unregister:
++	if (sd->internal_ops && sd->internal_ops->unregistered)
++		sd->internal_ops->unregistered(sd);
++error_module:
++	module_put(sd->owner);
++	sd->v4l2_dev = NULL;
++	return err;
+ }
+ EXPORT_SYMBOL_GPL(v4l2_device_register_subdev);
+ 
+-- 
+1.7.9.5
+

--- a/recipes-kernel/linux/linux-gumstix_3.5.7.bb
+++ b/recipes-kernel/linux/linux-gumstix_3.5.7.bb
@@ -10,7 +10,7 @@ BOOT_SPLASH ?= "logo_linux_clut224-generic.ppm"
 # Patches for all releases in linux-3.5.y but PV specifies upstream base.
 # Patches at: git://github.com/gumstix/linux.git;branch=omap-3.5
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-gumstix-3.5:"
-PR = "r1"
+PR = "r2"
 
 S = "${WORKDIR}/git"
 
@@ -49,6 +49,7 @@ SRC_URI = " \
     file://0030-Fix-sprz319-erratum-2.1.patch \
     file://0031-OMAP2-3-clock-fix-sprz319-erratum-2.1.patch \
     file://0032-OMAP3-overo-increase-linux-partition-to-8-MiB.patch \
+    file://0033-v4l-Reset-subdev-v4l2_dev-field-to-NULL-if-registrat.patch \
     file://defconfig \
     file://${BOOT_SPLASH} \
 "


### PR DESCRIPTION
The standard kernel build has support for the mt9v032 "Caspa" camera, but if
one is not installed the hardware probe fails.  In this situation a driver
bug caused the module reference count to be decremented too many times,
making it impossible to unload the module, for example to allow the module
supporting a different camera to be loaded instead.

NB: This upstream patch first appeared in Linux 3.9 and was modified to
reflect the location of the sources in the 3.5 kernel.

**Note** I've updated the [kernel collected patch branch](https://github.com/pabigot/linux/tree/gumstix/dylan/linux-gumstix-3.5) to include this one.  The linux-gumstix-3.5.7.bb recipe documents that the omap-3.5 branch of the gumstix linux repo contains these patches, but it does not.  This discrepancy should be reconciled by either updating the branch or changing the recipe documentation.  (Note that the recipe and the branch are intentionally based on v3.5 not on whatever update version is actively used; this simplifies generating the patches for meta-gumstix by using "git format-patch v3.5" and adding the new ones in the correct, linearly increasing, order.)
