### PR TITLE
u-boot: Fix LICENSE errors

### DIFF
--- a/recipes-bsp/u-boot/u-boot-gumstix.inc
+++ b/recipes-bsp/u-boot/u-boot-gumstix.inc
@@ -1,8 +1,9 @@
-require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc
+require recipes-bsp/u-boot/u-boot.inc
 
 # The license text is moved from a "COPYING" file to the beginning of
 # the README on recent versions of u-boot.
 LIC_FILES_CHKSUM = "file://README;beginline=1;endline=6;md5=157ab8408beab40cd8ce1dc69f702a6c"
+LICENSE = "GPLv2+"
 
 # To deploy a u-boot environment file, uncomment these lines
 #UBOOT_ENV = "uEnv"

--- a/recipes-bsp/u-boot/u-boot_2015.07.bb
+++ b/recipes-bsp/u-boot/u-boot_2015.07.bb
@@ -1,4 +1,4 @@
-require u-boot.inc
+require u-boot-gumstix.inc
 
 PV = "2015.07"
 

--- a/recipes-bsp/u-boot/u-boot_2016.01.bb
+++ b/recipes-bsp/u-boot/u-boot_2016.01.bb
@@ -1,4 +1,4 @@
-require u-boot.inc
+require u-boot-gumstix.inc
 
 PV = "2016.01"
 


### PR DESCRIPTION
also rename u-boot.inc to u-boot-gumstix.inc to avoid
file namespace collisions.

Add LICENSE field in u-boot-gumstix.inc

Fixes

ERROR: /mnt/a/work/oe/meta-gumstix/recipes-bsp/u-boot/u-boot_2016.01.bb: This recipe does not have the LICENSE field set (u-boot)                                                                                             | ETA:  --:--:--
ERROR: /mnt/a/work/oe/meta-gumstix/recipes-bsp/u-boot/u-boot_2015.07.bb: This recipe does not have the LICENSE field set (u-boot)

Signed-off-by: Khem Raj raj.khem@gmail.com
