### PR TITLE
Add property to sdio-wlink8 to make wifi work

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi-4.19/0010-Add-property-to-sdio-wlink8.patch
+++ b/recipes-kernel/linux/linux-raspberrypi-4.19/0010-Add-property-to-sdio-wlink8.patch
@@ -1,3 +1,12 @@
+From ec0bee72290f0894ac5a72a75e9692dbb78e3397 Mon Sep 17 00:00:00 2001
+From: Harry <harry.hu@gumstix.com>
+Date: Mon, 6 Jan 2020 09:58:13 -0800
+Subject: [PATCH] Add property to sdio-wlink8 to make wifi work.
+
+---
+ arch/arm/boot/dts/overlays/sdio-wlink8-overlay.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm/boot/dts/overlays/sdio-wlink8-overlay.dts b/arch/arm/boot/dts/overlays/sdio-wlink8-overlay.dts
 index 09a45fda0aac..c884fe50ee41 100644
 --- a/arch/arm/boot/dts/overlays/sdio-wlink8-overlay.dts
@@ -10,3 +19,6 @@ index 09a45fda0aac..c884fe50ee41 100644
                          bus-width = <4>;
                          brcm,overclock-50 = <0>;
                          status = "okay";
+-- 
+2.17.1
+


### PR DESCRIPTION
Add property to sdio-wlink8 to make wifi on warrior work, and added in commit information to the patch.