### PR TITLE
Forced IIO to be built in to the kernel 

### DIFF
--- a/recipes-kernel/linux/fragments/enable_iio.cfg
+++ b/recipes-kernel/linux/fragments/enable_iio.cfg
@@ -1,0 +1,1 @@
+CONFIG_IIO=y


### PR DESCRIPTION
By forcing IIO to be built into the kernel, we can avoid having to patch device drivers (for example: BME680) that lack compatible strings. 