### PR TITLE
Renamed enable_iio.cfg to 0000-enable_iio.cfg

### DIFF
--- a/recipes-kernel/linux/fragments/0000-enable_iio.cfg
+++ b/recipes-kernel/linux/fragments/0000-enable_iio.cfg
@@ -1,0 +1,1 @@
+CONFIG_IIO=y

--- a/recipes-kernel/linux/fragments/enable_iio.cfg
+++ b/recipes-kernel/linux/fragments/enable_iio.cfg
@@ -1,0 +1,1 @@
+CONFIG_IIO=y

--- a/recipes-kernel/linux/fragments/enable_iio.cfg
+++ b/recipes-kernel/linux/fragments/enable_iio.cfg
@@ -1,1 +1,0 @@
-CONFIG_IIO=y


### PR DESCRIPTION
This is to force IIO to be built into the kernel (to avoid having to patch the kernel drivers for various drivers that don't have a .compatible string).