### PR TITLE
Disabled regulator in the device tree of warrior duovero

### DIFF
--- a/recipes-devtools/gcc/gcc-source/0050-fix-libsanitizer-ustat.patch
+++ b/recipes-devtools/gcc/gcc-source/0050-fix-libsanitizer-ustat.patch
@@ -1,0 +1,62 @@
+From 61f38c64c01a15560026115a157b7021ec67bd3b Mon Sep 17 00:00:00 2001
+From: hjl <hjl@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date: Thu, 24 May 2018 20:21:54 +0000
+Subject: [PATCH] libsanitizer: Use pre-computed size of struct ustat for Linux
+
+Cherry-pick compiler-rt revision 333213:
+
+<sys/ustat.h> has been removed from glibc 2.28 by:
+
+commit cf2478d53ad7071e84c724a986b56fe17f4f4ca7
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Sun Mar 18 11:28:59 2018 +0800
+
+    Deprecate ustat syscall interface
+
+This patch uses pre-computed size of struct ustat for Linux.
+
+	PR sanitizer/85835
+	* sanitizer_common/sanitizer_platform_limits_posix.cc: Don't
+	include <sys/ustat.h> for Linux.
+	(SIZEOF_STRUCT_USTAT): New.
+	(struct_ustat_sz): Use SIZEOF_STRUCT_USTAT for Linux.
+
+
+
+git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/branches/gcc-7-branch@260688 138bc75d-0d04-0410-961f-82ee72b054a4
+---
+ .../sanitizer_platform_limits_posix.cc            | 15 +++++++++++++--
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+index 31a5e697eae3..8017afd21c53 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -154,7 +154,6 @@ typedef struct user_fpregs elf_fpregset_t;
+ # include <sys/procfs.h>
+ #endif
+ #include <sys/user.h>
+-#include <sys/ustat.h>
+ #include <linux/cyclades.h>
+ #include <linux/if_eql.h>
+ #include <linux/if_plip.h>
+@@ -247,7 +246,19 @@ namespace __sanitizer {
+ #endif // SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);
+ #endif // SANITIZER_LINUX && !SANITIZER_ANDROID

--- a/recipes-devtools/gcc/gcc-source_7.3.bbappend
+++ b/recipes-devtools/gcc/gcc-source_7.3.bbappend
@@ -1,0 +1,5 @@
+FILEEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+ 
+SRC_URI_append = "\
+    file://0050-fix-libsanitizer-ustat.patch \
+"

--- a/recipes-kernel/linux/linux-yocto-5.0/0023-Disabled-regulator-on-duovero-warrior-dtb.patch
+++ b/recipes-kernel/linux/linux-yocto-5.0/0023-Disabled-regulator-on-duovero-warrior-dtb.patch
@@ -1,0 +1,65 @@
+From 7108ab0e3aa65fdd21c07e9d82a1aa0a7d5c7126 Mon Sep 17 00:00:00 2001
+From: Harry <harry.hu@gumstix.com>
+Date: Mon, 13 Jan 2020 12:42:57 -0800
+Subject: [PATCH] Disabled regulator in the device tree for making wilink work
+
+---
+ arch/arm/boot/dts/omap4-duovero.dtsi | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/arch/arm/boot/dts/omap4-duovero.dtsi b/arch/arm/boot/dts/omap4-duovero.dtsi
+index 7472530233ff..288b978b6181 100644
+--- a/arch/arm/boot/dts/omap4-duovero.dtsi
++++ b/arch/arm/boot/dts/omap4-duovero.dtsi
+@@ -52,9 +52,9 @@
+ 		compatible = "regulator-fixed";
+ 	};
+ 
+-	wlcore_wl_en: fixedregulator@1 {
+-		compatible = "regulator-fixed";
+-	};
++//	wlcore_wl_en: fixedregulator@1 {
++//		compatible = "regulator-fixed";
++//	};
+ 
+ 	wlcore_bt_en: fixedregulator@2 {
+ 		compatible = "regulator-fixed";
+@@ -249,16 +249,16 @@
+ 	regulator-max-microvolt = <5000000>;
+ };
+ 
+-&wlcore_wl_en {
+-        regulator-name = "regulator-wlcore-wl-en";
+-        regulator-min-microvolt = <3300000>;
+-        regulator-max-microvolt = <3300000>;
+-        vin-supply = <&vbat>;
+-        gpio = <&gpio2 11 0>;   /* gpio_43: WL Enable */
+-        /* WLAN card specific delay */
+-        startup-delay-us = <70000>;
+-        enable-active-high;
+-};
++//&wlcore_wl_en {
++//        regulator-name = "regulator-wlcore-wl-en";
++//        regulator-min-microvolt = <3300000>;
++//        regulator-max-microvolt = <3300000>;
++//        vin-supply = <&vbat>;
++//        gpio = <&gpio2 11 0>;   /* gpio_43: WL Enable */
++//        /* WLAN card specific delay */
++//        startup-delay-us = <70000>;
++//        enable-active-high;
++//};
+ 
+ &wlcore_bt_en {
+         regulator-name = "regulator-wlcore-bt-en";
+@@ -276,7 +276,7 @@
+ 	pinctrl-0 = <&mmc5_pins>;
+ 	ti,bus-width = <4>;
+ 	vmmc-supply = <&vmmc>;
+-	vmmc_aux-supply = <&wlcore_wl_en>;
++//	vmmc_aux-supply = <&wlcore_wl_en>;
+ 	vqmmc-supply = <&wlcore_bt_en>;
+ 	ti,non-removable;
+ 	ti,needs-special-hs-handling;
+-- 
+2.17.1
+


### PR DESCRIPTION
Disabled the regulator in the device tree (omap4-duovero.dtsi) of warrior duovero to make wilink work properly