### PR TITLE
Adding SERIAL_CONSOLES variable to disable getty on ttyAMA0 and Addin…

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -246,3 +246,4 @@ DISTRO_FEATURES_append = " bluez5"
 KERNEL_DEVICETREE_append = " overlays/sdio.dtbo"
 RPI_EXTRA_CONFIG += '\n#For SDIO Interface:\ndtoverlay=sdio,poll_once=off'
 
+SERIAL_CONSOLES_rpi = "115200;ttyS0"

--- a/recipes-connectivity/bluez/bluez5-5.%/bluetooth-ttyAMA0-wilink.service
+++ b/recipes-connectivity/bluez/bluez5-5.%/bluetooth-ttyAMA0-wilink.service
@@ -1,8 +1,12 @@
 [Unit]
-Description=Attach WiLink8 Bluetooth Adapter hardwired to ttyO1
-Wants=bluetooth.service
+Description=Attach WiLink8 Bluetooth Adapter hardwired to ttyAMA0
+Requires=bluetooth.service
+After=bluetooth.service
+BindsTo=bluetooth.service
 
 [Service]
+Type=simple
+ExecStartPre=/bin/sleep 1
 ExecStart=/usr/bin/hciattach -n ttyAMA0 texas
 # is UIM needed?
 


### PR DESCRIPTION
Adding delay to bluetooth-ttyAMA0-wilink service and adding SERIAL_CONSOLES_rpi variable in local.conf.sample to boot serial console on proper port